### PR TITLE
json_encode_dict -> json (Python 3.6)

### DIFF
--- a/lxc/containers.sls
+++ b/lxc/containers.sls
@@ -20,8 +20,8 @@ include:
         template: {{ salt['pillar.get']("lxc:container_profile:{}:template".format(config.get("profile"))) }}
         name: {{ name }}
         arch: amd64
-        interfaces: {{ config.get("interfaces", {}) | json_encode_dict }}
-        config: {{ config.get("config", {}) | json_encode_dict }}
+        interfaces: {{ config.get("interfaces", {}) | json }}
+        config: {{ config.get("config", {}) | json }}
         network_profile: {{ config.get("network_profile") }}
 
 "restart_lxc_{{ name }}":


### PR DESCRIPTION
Ensure Python 3.6 compatibility.

Tested on FreeBSD 11.2 with `salt-ssh` to Ubuntu 18.04.